### PR TITLE
Update Atlantic configs for release/testnet2/v0.10.1

### DIFF
--- a/atlantic/24c96g/conf/mygrid.conf.json
+++ b/atlantic/24c96g/conf/mygrid.conf.json
@@ -46,7 +46,7 @@
         "mygrid_master_to_server_auto_prune_period_us": 1800000000,
         "letus_merkle_enable_trie_logical_page_release": true,
         "letus_batch_update_logical_page_size": 50000,
-        "letus_prune_compaction_max_concurrent_count": 8,
+        "letus_prune_compaction_max_concurrent_count": 6,
         "letus_max_file_count_for_prune_compaction": 6,
         "letus_slow_index_file_read": 100000,
         "letus_io_throttle_rw_bps": 209715200,

--- a/atlantic/24c96g/conf/txpool.conf
+++ b/atlantic/24c96g/conf/txpool.conf
@@ -15,7 +15,7 @@
     "/GlobalFlag/metrics_collect_interval_ms": "3000",
     "/GlobalFlag/partition_group_size_powner_exponent": "5",
     "/GlobalFlag/partition_group_propose_max_batch_size": "8000",
-    "/GlobalFlag/partition_group_propose_max_interval_us": "10000",
+    "/GlobalFlag/partition_group_propose_max_interval_us": "100000",
     "/GlobalFlag/partition_group_persist_max_batch_size": "8000",
     "/GlobalFlag/partition_group_persist_max_interval_us": "100000",
     "/GlobalFlag/forward_permit_window_size": "200",

--- a/atlantic/64cUnlimited/conf/mygrid.conf.json
+++ b/atlantic/64cUnlimited/conf/mygrid.conf.json
@@ -45,7 +45,7 @@
         "mygrid_master_to_server_auto_prune_period_us": 1800000000,
         "letus_merkle_enable_trie_logical_page_release": true,
         "letus_batch_update_logical_page_size": 50000,
-        "letus_prune_compaction_max_concurrent_count": 8,
+        "letus_prune_compaction_max_concurrent_count": 6,
         "letus_max_file_count_for_prune_compaction": 6,
         "letus_slow_index_file_read": 100000,
         "letus_io_throttle_rw_bps": 209715200,

--- a/atlantic/64cUnlimited/conf/txpool.conf
+++ b/atlantic/64cUnlimited/conf/txpool.conf
@@ -15,7 +15,7 @@
     "/GlobalFlag/metrics_collect_interval_ms": "3000",
     "/GlobalFlag/partition_group_size_powner_exponent": "4",
     "/GlobalFlag/partition_group_propose_max_batch_size": "8000",
-    "/GlobalFlag/partition_group_propose_max_interval_us": "10000",
+    "/GlobalFlag/partition_group_propose_max_interval_us": "100000",
     "/GlobalFlag/partition_group_persist_max_batch_size": "8000",
     "/GlobalFlag/partition_group_persist_max_interval_us": "100000",
     "/GlobalFlag/forward_permit_window_size": "200",


### PR DESCRIPTION
## Atlantic Configuration Update

**Source branch:** release/testnet2/v0.10.1
**Commit:** 0157bd6e

### Updated configurations:
• low_mem (24c96g)
• high_mem (64cUnlimited)