### PR TITLE
chore: drop LD_PRELOAD=libevmone.so from entrypoint

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -88,8 +88,7 @@ if [ "$BOOTSTRAPPED" = false ]; then
     echo "Running: pharos_cli genesis -c $PHAROS_CONF -g $GENESIS_CONF"
     
     # Run bootstrap (not as exec, so we can continue after)
-    env LD_PRELOAD=./libevmone.so \
-        CONSENSUS_KEY_PWD="$CONSENSUS_KEY_PWD" \
+    env CONSENSUS_KEY_PWD="$CONSENSUS_KEY_PWD" \
         PORTAL_SSL_PWD="$PORTAL_SSL_PWD" \
         ./pharos_cli genesis -c "$PHAROS_CONF" -g "$GENESIS_CONF"
     
@@ -100,7 +99,6 @@ echo "Starting pharos node..."
 echo "Running: pharos_light -c $PHAROS_CONF"
 
 # Start pharos_light as main process (PID 1)
-exec env LD_PRELOAD=./libevmone.so \
-    CONSENSUS_KEY_PWD="$CONSENSUS_KEY_PWD" \
+exec env CONSENSUS_KEY_PWD="$CONSENSUS_KEY_PWD" \
     PORTAL_SSL_PWD="$PORTAL_SSL_PWD" \
     ./pharos_light -c "$PHAROS_CONF"


### PR DESCRIPTION
## What
`docker-entrypoint.sh` 去掉两处 `LD_PRELOAD=./libevmone.so`（pharos_cli genesis 引导 + pharos_light 主进程）。

## Why
v0.14.2 起 evmone **静态链接**进 pharos_light / pharos_cli，不再产出独立的
`libevmone.so`，二进制也没有对它的 NEEDED 依赖。保留 `LD_PRELOAD=./libevmone.so`
会因文件缺失导致节点**启动失败**。

配套：构建侧 Jenkinsfile 也已去掉 `cp libevmone.so`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)